### PR TITLE
Add MJS and sourceType: module support

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -202,6 +202,7 @@ function wp_get_plugin_file_editable_extensions( $plugin ) {
 		'inc',
 		'include',
 		'js',
+		'mjs',
 		'json',
 		'jsx',
 		'less',

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -262,6 +262,7 @@ function wp_get_theme_file_editable_extensions( $theme ) {
 		'inc',
 		'include',
 		'js',
+		'mjs',
 		'json',
 		'jsx',
 		'less',

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4152,6 +4152,7 @@ function wp_get_code_editor_settings( $args ) {
 		),
 		'jshint'     => array(
 			'esversion' => 11,
+			'module'    => str_ends_with( $args['file'] ?? '', '.mjs' ) ? true : false,
 
 			// The following JSHint *linting rule* options are copied from
 			// <https://github.com/WordPress/wordpress-develop/blob/6.9.0/.jshintrc>.
@@ -4239,6 +4240,7 @@ function wp_get_code_editor_settings( $args ) {
 					$type = 'message/http';
 					break;
 				case 'js':
+				case 'mjs':
 					$type = 'text/javascript';
 					break;
 				case 'json':

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4152,7 +4152,7 @@ function wp_get_code_editor_settings( $args ) {
 		),
 		'jshint'     => array(
 			'esversion' => 11,
-			'module'    => str_ends_with( $args['file'] ?? '', '.mjs' ) ? true : false,
+			'module'    => str_ends_with( $args['file'] ?? '', '.mjs' ),
 
 			// The following JSHint *linting rule* options are copied from
 			// <https://github.com/WordPress/wordpress-develop/blob/6.9.0/.jshintrc>.


### PR DESCRIPTION
Builds on https://github.com/WordPress/wordpress-develop/pull/10806 to add `.mjs` module support.

[Checking the extension for module grammar aligns with IANA media type definition:](https://www.iana.org/assignments/media-types/text/javascript)

> Restrictions on usage:  The .mjs file extension signals that the file
>    represents a JavaScript module.  Execution environments that rely
>    on file extensions to determine how to process inputs parse .mjs
>    files using the Module grammar of [ECMA-262].

This can be merged into the existing PR or considered on its own.